### PR TITLE
devcontainer.json uses local dockerfile image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,10 @@
 				"editor.codeActionsOnSave": {
 					"source.organizeImports": true
 				}
-			}
+			},
+			"extensions": [
+				"ms-python.python"
+			]
 		}
 	},
 	"postCreateCommand": "cd /workspace/cell_observatory_platform && export PATH=$PATH:/home/ubuntu/.local/bin && pip install bpytop  --no-dependencies && cp ~/.bashrc /tmp/host_bashrc && echo 'source /tmp/host_bashrc' >> ~/.bashrc && python3 --version",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,16 @@
 {
 	"name": "Cell Observatory Platform",
-	"image": "ghcr.io/cell-observatory/cell_observatory_platform:develop_torch_25_08",
+	"build": {
+		// These lines will build from Dockerfile otherwise comment these and uncomment "image" below		
+		"dockerfile": "../Dockerfile",
+		"context": "..",
+		"options": [
+			"--progress=plain"
+		],
+		"target": "torch_25_08"
+	},
+	// Uncomment this to use a pre-built image instead of building from the Dockerfile
+	// "image": "ghcr.io/cell-observatory/cell_observatory_platform:develop_torch_25_08",
 	"workspaceFolder": "/workspace/cell_observatory_platform",
 	"containerUser": "ubuntu",
 	"overrideCommand": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,8 @@
 			"extensions": [
 				"ms-python.python",
 				"eamodio.gitlens",
-				"github.vscode-github-actions"
+				"github.vscode-github-actions",
+				"mechatroner.rainbow-csv"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
 				],
 				"editor.formatOnSave": true,
 				"editor.codeActionsOnSave": {
-					"source.organizeImports": true
+					"source.organizeImports": "always"
 				}
 			},
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,6 @@
 			}
 		}
 	},
-	"postCreateCommand": "cd /workspace/cell_observatory_platform && export PATH=$PATH:/home/ubuntu/.local/bin && pip install --upgrade psutil && pip install nvitop bpytop && cp ~/.bashrc /tmp/host_bashrc && echo 'source /tmp/host_bashrc' >> ~/.bashrc && python3 --version",
+	"postCreateCommand": "cd /workspace/cell_observatory_platform && export PATH=$PATH:/home/ubuntu/.local/bin && pip install bpytop  --no-dependencies && cp ~/.bashrc /tmp/host_bashrc && echo 'source /tmp/host_bashrc' >> ~/.bashrc && python3 --version",
 	"postStartCommand": "cd /workspace/cell_observatory_platform && export PATH=$PATH:/home/ubuntu/.local/bin && export PYTHONPATH=/workspace/cell_observatory_platform && source ~/.bashrc"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,9 @@
 				}
 			},
 			"extensions": [
-				"ms-python.python"
+				"ms-python.python",
+				"eamodio.gitlens",
+				"github.vscode-github-actions"
 			]
 		}
 	},

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ COPY requirements.txt requirements.txt
 
 FROM pip_install AS torch_25_08
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements.txt --progress-bar off --cache-dir /root/.cache/pip
+    pip install -r requirements.txt --progress-bar off --root-user-action=ignore --cache-dir /root/.cache/pip
 
 # Code to avoid running as root
 ARG USERNAME=user1000


### PR DESCRIPTION
Allows `devcontainer.json` to build dockerfile locally based upon your current requirements.txt file.  This makes testing a new requirements.txt file easy.  Once dev container is built, it is instant to start up dev container.  Lots of caching with docker makes rebuilding the dev container pretty quick as well. 